### PR TITLE
Change armor slot accept condition to be consistent with accessories

### DIFF
--- a/Defaults/Inventories/Armor.cs
+++ b/Defaults/Inventories/Armor.cs
@@ -10,7 +10,7 @@ public abstract class AArmor : ModSubInventory {
     public abstract bool IsArmor(Item item);
 
     public override int Context => ContextID.EquipArmor;
-    public override bool Accepts(Item item) => IsArmor(item) && item.defense != 0;
+    public override bool Accepts(Item item) => IsArmor(item) && !item.vanity;
     public override bool IsDefault(Item item) => true;
     public override Joined<ListIndices<Item>, Item> Items(Player player) => new ListIndices<Item>(player.armor, Index);
 


### PR DESCRIPTION
### What is the bug?
Main armor slots would only accept items that gave `defense`. However some armor items can go in armor slots and don't provide any defense. This means that you could not use the hot keys to quickly swap certain items into the correct slots. Some vanilla examples include: `Wood Legs`, `Amethyst Robe`, and `Djinn's Curse`. It was also messing with the `Final Fantasy Distant Memories` mod where all the individual armor pieces do not provide armor, only the full set.

### Proof
![ArmorSlot](https://github.com/Spiky-73/BetterInventory/assets/56134537/5065db3b-5109-469f-a4d4-2fed09cf834f)


### How did you fix the bug?
Change the condition to `!item.vanity` similar to accessory slots.

### Are there alternatives to your fix?
I don't know. I guess the case where it is both a vanity item and has defense might need to be considered. As far as I know `item.vanity` is the only condition checked for when doing a regular right click equip.
