### PR TITLE
Fix infinite grab bags glitch

### DIFF
--- a/Utility.cs
+++ b/Utility.cs
@@ -24,6 +24,8 @@ public static class Utility {
                     && (!notArg || player.inventory[i] != item))
                 currentMin = player.inventory[i];
         }
+        if (currentMin == player.inventory[58])
+            Main.mouseItem = currentMin;
         return currentMin;
     }
 }


### PR DESCRIPTION
### What is the bug?
Grab bags can be infinitely opened under the following circumstance:

1. `Smart item consumption` is enabled for `Consumables`
2. Having a grab bag in the mouse slot
3. Right clicking another inventory slot containing a compatible grab bag

### Proof
![InfiniteBags](https://github.com/Spiky-73/BetterInventory/assets/56134537/535b969a-d9cf-4d3f-88b4-6b371a9a0527)


### How did you fix the bug?
If the smart stack selected by `Utility.SmallestStack()` is the mouse item (slot 58) then set `Main.mouseItem` to that selected stack. Note that returning `Main.mouseItem` directly does not work.

### Are there alternatives to your fix?
I'm not confident that setting `Main.mouseItem` in this way is safe. Vanilla often makes a `Clone` of slot 58 before setting `Main.mouseItem` as seen at the end of  `Player.ItemCheck_Inner()`. More changes would need to be made to do it safely in that way. From my limited testing this was not an issue, but you never know.

Another option would be to have `SmallestStack()` return null for grab bags which restores vanilla behavior, but would lose smart consumption.