### PR TITLE
v0.9.0.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Better Inventory changelog
 
+## v0.9.0.2
+- Fixed Refill Mouse Items deleting favorited stackable items
+- Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
+
 ## v0.9.0.1
 - Added Move Items To Return to Previous Slot
 - Fixed Refill Mouse Item not been able to be disabled

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## v0.9.0.2
 - Fixed Refill Mouse Items deleting favorited stackable items
 - Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
+- Made Move Items in Return to Previous Slot more granular
 
 ## v0.9.0.1
 - Added Move Items To Return to Previous Slot

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 - Fixed Refill Mouse Items deleting favorited stackable items
 - Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
 - Made Move Items in Return to Previous Slot more granular
+- Fixed right-clicking items not marking items or removing marks
+- Fixed Return to Previous Slot on Consumption marking items when it should not
 
 ## v0.9.0.1
 - Added Move Items To Return to Previous Slot

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 - Made Move Items in Return to Previous Slot more granular
 - Fixed right-clicking items not marking items or removing marks
 - Fixed Return to Previous Slot on Consumption marking items when it should not
+- Changed Smart Consumption to not be applied if the mouse item is consumed and Include Mouse is disabled
+- Fixed Recipe Sort been disabled by default
 
 ## v0.9.0.1
 - Added Move Items To Return to Previous Slot

--- a/Configs/Crafting.cs
+++ b/Configs/Crafting.cs
@@ -9,7 +9,7 @@ public sealed class Crafting : ModConfig {
     public Toggle<FixedUI> fixedUI = new(true);
     public Toggle<RecipeSearchBar> recipeSearchBar = new(true);
     public Toggle<RecipeFilters> recipeFilters = new(true);
-    public bool recipeSort = true;
+    [DefaultValue(true)] public bool recipeSort = true;
     public Toggle<CraftOnList> craftOnList = new(true);
     public Toggle<MoreMaterials> moreMaterials = new(true);
     public Toggle<AvailableMaterials> availableMaterials = new(true);

--- a/Configs/InventoryManagement.cs
+++ b/Configs/InventoryManagement.cs
@@ -110,7 +110,7 @@ public sealed class PreviousSlot {
     [DefaultValue(true)] public bool consumption = true;
     [DefaultValue(true)] public bool mediumCore = true;
     [DefaultValue(false)] public bool overridePrevious = false;
-    [DefaultValue(true)] public bool moveItems = true;
+    [DefaultValue(MovePolicy.NotFavorited)] public MovePolicy movePolicy = MovePolicy.NotFavorited;
     public Toggle<Materials> materials = new(true);
     public Toggle<PreviousDisplay> displayPrevious = new(true);
 
@@ -120,10 +120,12 @@ public sealed class PreviousSlot {
     public static PreviousSlot Value => SmartPickup.Value.previousSlot.Value;
 }
 
+public enum MovePolicy { Never, NotFavorited, Always }
+
 public sealed class QuickStackPickup {
     [DefaultValue(true)] public bool voidBag = true;
     [DefaultValue(true)] public bool chests = true;
-    
+
     public static QuickStackPickup Value => SmartPickup.Value.quickStack.Value;
 }
 

--- a/InventoryManagement/SmartPickup/SmartEquip.cs
+++ b/InventoryManagement/SmartPickup/SmartEquip.cs
@@ -1,5 +1,6 @@
 using BetterInventory.Default.Inventories;
 using SpikysLib;
+using SpikysLib.Constants;
 using Terraria;
 using Terraria.Audio;
 using Terraria.ID;
@@ -9,7 +10,7 @@ namespace BetterInventory.InventoryManagement.SmartPickup;
 public static class SmartEquip {
 
     public static Item RefillMouse(Player player, Item item, GetItemSettings settings) {
-        if (item == Main.mouseItem || Main.mouseItem.IsAir || Main.mouseItem.type != item.type) return item;
+        if (item == Main.mouseItem || item == player.inventory[InventorySlots.Mouse] || Main.mouseItem.IsAir || Main.mouseItem.type != item.type) return item;
         Main.mouseItem = ItemHelper.MoveInto(Main.mouseItem, item, out int transferred, item.maxStack);
         if (transferred == 0) return item;
         SoundEngine.PlaySound(SoundID.Grab);

--- a/InventoryManagement/SmartPickup/SmartPickup.cs
+++ b/InventoryManagement/SmartPickup/SmartPickup.cs
@@ -33,8 +33,8 @@ public sealed class SmartPickup : ModSystem {
         // ++ item = <previousSlot>
         EmitSmartPickup(cursor, newItem, (Player self, int plr, Item item, GetItemSettings settings) => {
             if (vanillaGetItem) return item;
-            if (Configs.SmartPickup.RefillMouse) item = SmartEquip.RefillMouse(self, item, settings);
-            if (Configs.SmartPickup.PreviousSlot) item = self.GetModPlayer<PreviousSlotPlayer>().PickupItemToPreviousSlot(self, item, settings);
+            if (!item.IsAir && Configs.SmartPickup.RefillMouse) item = SmartEquip.RefillMouse(self, item, settings);
+            if (!item.IsAir && Configs.SmartPickup.PreviousSlot) item = self.GetModPlayer<PreviousSlotPlayer>().PickupItemToPreviousSlot(self, item, settings);
             return item;
         });
     }
@@ -61,10 +61,10 @@ public sealed class SmartPickup : ModSystem {
         EmitSmartPickup(cursor, newItem, (Player self, int plr, Item item, GetItemSettings settings) => {
             if (vanillaGetItem || settings.NoText) return item;
             if (!item.IsAir && Configs.SmartPickup.QuickStack) item = SmartEquip.QuickStack(self, item, settings);
-            if (Configs.SmartPickup.FixAmmo && item.FitsAmmoSlot()) item = self.FillAmmo(plr, item, settings);
+            if (!item.IsAir && Configs.SmartPickup.FixAmmo && item.FitsAmmoSlot()) item = self.FillAmmo(plr, item, settings);
             if (!item.IsAir && Configs.SmartPickup.UpgradeItems) item = SmartEquip.UpgradeItems(self, item, settings);
             if (!item.IsAir && Configs.SmartPickup.AutoEquip) item = SmartEquip.AutoEquip(self, item, settings);
-            if (!item.IsAir && Configs.SmartPickup.VoidBagFirst) item = SmartEquip.VoidBagFirst(self, item, settings);
+            if (!item.IsAir && !item.favorited && Configs.SmartPickup.VoidBagFirst) item = SmartEquip.VoidBagFirst(self, item, settings);
             return item;
         });
     }

--- a/Localization/en-US/Mods.BetterInventory.Chat.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Chat.hjson
@@ -20,5 +20,7 @@ Changelog:
 	- Made Move Items in Return to Previous Slot more granular
 	- Fixed right-clicking items not marking items or removing marks
 	- Fixed Consumption in Return to Previous Slot marking items when it should not
+	- Changed Smart Consumption to not be applied if the mouse item is consumed and Include Mouse is disabled
+	- Fixed Recipe Sort been disabled by default
 	'''
 Version: 0.9.0.1

--- a/Localization/en-US/Mods.BetterInventory.Chat.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Chat.hjson
@@ -11,12 +11,11 @@ ModName: Better Inventory
 SPIC.ModName: Spy's Infinite Consumables
 Homepage: homepage
 Workshop: Steam Workshop page
-Summary: Bugs related to Refill Mouse Item and favorited items should be fixed
+Summary: Some more bugs where fixed
 Details: ""
 Changelog:
 	'''
-	- Added Move Items To Return to Previous Slot
-	- Fixed Refill Mouse Item not been able to be disabled
-	- Fixed Refill Mouse Item making removing the favorited status of items
+	- Fixed Refill Mouse Items deleting favorited stackable items
+	- Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
 	'''
 Version: 0.9.0.1

--- a/Localization/en-US/Mods.BetterInventory.Chat.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Chat.hjson
@@ -18,5 +18,7 @@ Changelog:
 	- Fixed Refill Mouse Items deleting favorited stackable items
 	- Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
 	- Made Move Items in Return to Previous Slot more granular
+	- Fixed right-clicking items not marking items or removing marks
+	- Fixed Consumption in Return to Previous Slot marking items when it should not
 	'''
 Version: 0.9.0.1

--- a/Localization/en-US/Mods.BetterInventory.Chat.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Chat.hjson
@@ -11,7 +11,7 @@ ModName: Better Inventory
 SPIC.ModName: Spy's Infinite Consumables
 Homepage: homepage
 Workshop: Steam Workshop page
-Summary: Some more bugs where fixed
+Summary: Some more bugs where fixed including Refill Mouse Item sometime eating items
 Details: ""
 Changelog:
 	'''
@@ -23,4 +23,4 @@ Changelog:
 	- Changed Smart Consumption to not be applied if the mouse item is consumed and Include Mouse is disabled
 	- Fixed Recipe Sort been disabled by default
 	'''
-Version: 0.9.0.1
+Version: 0.9.0.2

--- a/Localization/en-US/Mods.BetterInventory.Chat.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Chat.hjson
@@ -17,5 +17,6 @@ Changelog:
 	'''
 	- Fixed Refill Mouse Items deleting favorited stackable items
 	- Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
+	- Made Move Items in Return to Previous Slot more granular
 	'''
 Version: 0.9.0.1

--- a/Localization/en-US/Mods.BetterInventory.Configs.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Configs.hjson
@@ -439,13 +439,6 @@ AutoEquip: {
 	}
 }
 
-VoidBagLevel: {
-	Tooltip: ""
-	None.Label: Off
-	IfInside.Label: If Inside
-	Always.Label: Always
-}
-
 PreviousSlot: {
 	Tooltip: ""
 
@@ -487,10 +480,23 @@ PreviousSlot: {
 		Tooltip: Materials crafted into another item will go to their previous slot in your inventory
 	}
 
-	moveItems: {
-		Label: Move items
-		Tooltip: If the old slot is not empty, move the items inside it to another inventory slot
+	movePolicy: {
+		Label: Move Items
+		Tooltip:
+			'''
+			Whether or not to move items if the previous slot is not empty
+			{$Mods.BetterInventory.Configs.MovePolicy.Never.Label}: Do not move any item
+			{$Mods.BetterInventory.Configs.MovePolicy.NotFavorited.Label}: Do not move favorited items
+			{$Mods.BetterInventory.Configs.MovePolicy.Always.Label}: Always move items unless they are favorited and the previous one is not
+			'''
 	}
+}
+
+MovePolicy: {
+	Tooltip: ""
+	Never.Label: Never
+	NotFavorited.Label: Not If Favorited
+	Always.Label: Always
 }
 
 Materials: {

--- a/Localization/en-US/Mods.BetterInventory.Configs.hjson
+++ b/Localization/en-US/Mods.BetterInventory.Configs.hjson
@@ -339,7 +339,11 @@ SmartConsumption: {
 
 	mouse: {
 		Label: Include Mouse Item
-		Tooltip: Includes the mouse item when searching for the item to consume
+		Tooltip:
+			'''
+			Applies Smart Consumption when consuming the mouse item
+			Checks if the mouse items is the smallest stack when consuming another item
+			'''
 	}
 
 	self: {

--- a/Utility.cs
+++ b/Utility.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using BetterInventory.InventoryManagement;
 using BetterInventory.InventoryManagement.SmartPickup;
 using MonoMod.Cil;
 using SpikysLib;
@@ -38,24 +39,24 @@ public static class Utility {
 
     public static int FailedILs { get; private set; }
 
-    public static Item? LastStack(this Player player, Item item, AllowedItems allowedItems = AllowedItems.None) {
-        bool Check(Item i) => item.type == i.type && (allowedItems.HasFlag(AllowedItems.Self) || i != item);
+    public static Item? LastStack(this Player player, Item item, StackPickerSettings settings) {
+        bool Check(Item i) => item.type == i.type && (settings.CanPickArg || i != item);
 
         for (int i = InventorySlots.Items.End - 1; i >= InventorySlots.Items.Start; i--) if (Check(player.inventory[i])) return player.inventory[i];
         for (int i = InventorySlots.Ammo.End - 1; i >= InventorySlots.Coins.Start; i--) if (Check(player.inventory[i])) return player.inventory[i];
-        if (allowedItems.HasFlag(AllowedItems.Mouse) && Check(player.inventory[InventorySlots.Mouse])) return player.inventory[InventorySlots.Mouse];
+        if (settings.CanPickMouse && Check(player.inventory[InventorySlots.Mouse])) return player.inventory[InventorySlots.Mouse];
         return null;
     }
 
-    public static Item? SmallestStack(this Player player, Item item, AllowedItems allowedItems = AllowedItems.None) {
+    public static Item? SmallestStack(this Player player, Item item, StackPickerSettings settings) {
         Item? min = null;
         void Check(Item i) {
-            if (item.type == i.type && (min is null || i.stack < min.stack) && (allowedItems.HasFlag(AllowedItems.Self) || i != item)) min = i;
+            if (item.type == i.type && (min is null || i.stack < min.stack) && (settings.CanPickArg || i != item)) min = i;
         }
 
         for (int i = InventorySlots.Items.End - 1; i >= InventorySlots.Items.Start; i--) Check(player.inventory[i]);
         for (int i = InventorySlots.Ammo.End - 1; i >= InventorySlots.Coins.Start; i--) Check(player.inventory[i]);
-        if (allowedItems.HasFlag(AllowedItems.Mouse)) Check(player.inventory[InventorySlots.Mouse]);
+        if (settings.CanPickMouse) Check(player.inventory[InventorySlots.Mouse]);
         return min;
     }
 

--- a/build.txt
+++ b/build.txt
@@ -1,6 +1,6 @@
 displayName = Better Inventory
 author = Spiky
-version = 0.9.0.1
+version = 0.9.0.2
 homepage = https://github.com/Spiky-73/BetterInventory/blob/master/README.md
 side = Client
 modReferences = SpikysLib@1.3.1


### PR DESCRIPTION
- Fixed Refill Mouse Items deleting favorited stackable items
- Fixed Pickup to Void Bag First moving favorited items inside the Void Bag
- Made Move Items in Return to Previous Slot more granular
- Fixed right-clicking items not marking items or removing marks
- Fixed Return to Previous Slot on Consumption marking items when it should not
- Changed Smart Consumption to not be applied if the mouse item is consumed and Include Mouse is disabled
- Fixed Recipe Sort been disabled by default